### PR TITLE
chore: Update Go dependencies to latest versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Go workspace file
+go.work
+
+# Build output
+flow-limit-proxy

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/bellwood4486/flow-limit-proxy
 
-go 1.21.6
+go 1.23.0
+
+toolchain go1.24.4
 
 require (
-	github.com/cenkalti/backoff/v4 v4.2.1
-	golang.org/x/sync v0.6.0
+	github.com/cenkalti/backoff/v4 v4.3.0
+	golang.org/x/sync v0.15.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
-github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
+golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=


### PR DESCRIPTION
## Summary
- Update Go version from 1.21.6 to 1.23.0
- Update github.com/cenkalti/backoff/v4 from v4.2.1 to v4.3.0  
- Update golang.org/x/sync from v0.6.0 to v0.15.0

## Test plan
- [x] Dependencies updated successfully
- [x] Application builds without errors
- [x] All changes committed and pushed

🤖 Generated with [Claude Code](https://claude.ai/code)